### PR TITLE
Proxy OpenAI requests via server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and replace with your OpenAI API key
+OPENAI_API_KEY=your-api-key-here

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # chatbot-wp
 
 A simple web-based chatbot using OpenAI's GPT-4o with Bulgarian language support.
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env.example` to `.env` and add your OpenAI API key:
+
+   ```
+   OPENAI_API_KEY=your-api-key-here
+   ```
+
+3. Start the server:
+
+   ```bash
+   npm start
+   ```
+
+The client code sends chat messages to `/api/chat`, which is proxied by the
+Express server using the API key from the `.env` file.

--- a/chat.js
+++ b/chat.js
@@ -1,4 +1,4 @@
-const apiKey = process.env.OPENAI_API_KEY; // използва ключа от променливата на средата
+// API key is kept on the server; client communicates with /api/chat
 const contact = "\uD83D\uDCDE \u0415\u0412\u0420\u041E \u041F\u0420\u041E\u0415\u041A\u0422 \u041A\u041E\u041C\u0415\u0420\u0421 \u0415\u041E\u041E\u0414\n\u260E\uFE0F 0877 887 673\n\u2709\uFE0F atanas7401@gmail.com";
 const systemPrompt = "Ти си полезен GPT-4o асистент на български.";
 let history = [{role: 'system', content: systemPrompt}];
@@ -27,9 +27,9 @@ function send() {
     const farewell = /(\bблагодаря\b|\bчао\b|\bдовиждане\b)/i.test(text);
     const payload = { model: 'gpt-4o', messages: history.concat({role: 'user', content: text}) };
 
-    fetch('https://api.openai.com/v1/chat/completions', {
+    fetch('/api/chat', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + apiKey },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
     })
     .then(r => r.ok ? r.json() : Promise.reject(r))
@@ -52,6 +52,3 @@ function send() {
 document.getElementById('toggle-btn').addEventListener('click', toggle);
 document.getElementById('send-btn').addEventListener('click', send);
 document.getElementById('user-input').addEventListener('keypress', (e)=>{ if(e.key==='Enter') send(); });
-// PR test
-// нов ред от тест
-// тестов ред за PR

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/atanas7401/chatbot-wp#readme",
   "dependencies": {
+    "dotenv": "^17.2.0",
     "express": "^5.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,13 +1,36 @@
+require('dotenv').config();
 const express = require('express');
 const app = express();
 
 app.use(express.json());
+app.use(express.static('.'));
 
-app.post('/api/chat', (req, res) => {
-  res.json({ message: 'OK' });
+app.post('/api/chat', async (req, res) => {
+  try {
+    const payload = {
+      model: 'gpt-4o',
+      messages: req.body.messages,
+    };
+    const apiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!apiResponse.ok) {
+      return res.status(apiResponse.status).json({ error: 'API request failed' });
+    }
+    const data = await apiResponse.json();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
 });
 
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server started on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add usage instructions to the README
- provide `.env.example` for API key configuration
- proxy OpenAI requests through Express server
- update frontend to call `/api/chat`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68820ef48dc48333bc371c0a69b21788